### PR TITLE
`<ctype.h>`: `tolower`, `toupper`

### DIFF
--- a/libc/include/ctype.h
+++ b/libc/include/ctype.h
@@ -10,6 +10,9 @@ int islower(int c);
 int isspace(int c);
 int isupper(int c);
 
+int tolower(int c);
+int toupper(int c);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libc/include/ctype.h
+++ b/libc/include/ctype.h
@@ -6,7 +6,9 @@ extern "C" {
 #endif
 
 int isdigit(int c);
+int islower(int c);
 int isspace(int c);
+int isupper(int c);
 
 #ifdef __cplusplus
 }

--- a/libc/src/ctype.c
+++ b/libc/src/ctype.c
@@ -23,3 +23,13 @@ int isupper(const int c)
 {
     return (unsigned)c - 'A' < 26;
 }
+
+int tolower(const int c)
+{
+    return isupper(c) ? (c + ('a' - 'A')) : c;
+}
+
+int toupper(const int c)
+{
+    return islower(c) ? (c - ('a' - 'A')) : c;
+}

--- a/libc/src/ctype.c
+++ b/libc/src/ctype.c
@@ -9,7 +9,17 @@ int isdigit(const int c)
     return (unsigned)c - '0' < 10;
 }
 
+int islower(const int c)
+{
+    return (unsigned)c - 'a' < 26;
+}
+
 int isspace(const int c)
 {
     return c == ' ' || (unsigned)c - '\t' < 5;
+}
+
+int isupper(const int c)
+{
+    return (unsigned)c - 'A' < 26;
 }


### PR DESCRIPTION
For mruby gem `mruby-compiler`, needed by `mruby-eval`.

```
mrbgems/mruby-compiler/core/parse.y: In function 'parser_yylex':
mrbgems/mruby-compiler/core/parse.y:5785:23: error: implicit declaration of function 'tolower' [-Werror=implicit-function-declaration]
 5785 |             tokadd(p, tolower(c));
      |                       ^~~~~~~
```