### PR TITLE
Require Autoconf 2.70

### DIFF
--- a/.github/sources.list
+++ b/.github/sources.list
@@ -1,9 +1,9 @@
-deb [arch=i386,amd64]    http://azure.archive.ubuntu.com/ubuntu focal           main restricted universe multiverse
-deb [arch=i386,amd64]    http://azure.archive.ubuntu.com/ubuntu focal-updates   main restricted universe multiverse
-deb [arch=i386,amd64]    http://azure.archive.ubuntu.com/ubuntu focal-backports main restricted universe multiverse
-deb [arch=i386,amd64]    http://azure.archive.ubuntu.com/ubuntu focal-security  main restricted universe multiverse
+deb [arch=i386,amd64]    http://azure.archive.ubuntu.com/ubuntu jammy           main restricted universe multiverse
+deb [arch=i386,amd64]    http://azure.archive.ubuntu.com/ubuntu jammy-updates   main restricted universe multiverse
+deb [arch=i386,amd64]    http://azure.archive.ubuntu.com/ubuntu jammy-backports main restricted universe multiverse
+deb [arch=i386,amd64]    http://azure.archive.ubuntu.com/ubuntu jammy-security  main restricted universe multiverse
 
-deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports   focal           main restricted universe multiverse
-deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports   focal-updates   main restricted universe multiverse
-deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports   focal-backports main restricted universe multiverse
-deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports   focal-security  main restricted universe multiverse
+deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports   jammy           main restricted universe multiverse
+deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports   jammy-updates   main restricted universe multiverse
+deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports   jammy-backports main restricted universe multiverse
+deb [arch=arm64,riscv64] http://ports.ubuntu.com/ubuntu-ports   jammy-security  main restricted universe multiverse

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo make install
 
   cross:
-    runs-on: ubuntu-20.04 # focal, because it's in ".github/sources.list"
+    runs-on: ubuntu-22.04 # jammy, because it's in ".github/sources.list"
     strategy:
       matrix:
         cross:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-12-05  Alex Kotov  <kotovalexarian@gmail.com>
+
+	* configure.ac: Fix a bug with building for a freestanding environment
+
 2022-12-04  Alex Kotov  <kotovalexarian@gmail.com>
 
 	libkernaux 0.6.0 released

--- a/README.md
+++ b/README.md
@@ -210,36 +210,6 @@ without it in `$PATH`:
   RANLIB="$(which i386-elf-ranlib)"
 ```
 
-You can see the following messages. It's
-[a bug](https://savannah.gnu.org/support/index.php?110393) in **autoconf**, just
-ignore it.
-
-```
-checking for _Bool... no
-checking stdarg.h usability... no
-checking stdarg.h presence... yes
-configure: WARNING: stdarg.h: present but cannot be compiled
-configure: WARNING: stdarg.h:     check for missing prerequisite headers?
-configure: WARNING: stdarg.h: see the Autoconf documentation
-configure: WARNING: stdarg.h:     section "Present But Cannot Be Compiled"
-configure: WARNING: stdarg.h: proceeding with the compiler's result
-configure: WARNING:     ## ---------------------------------------------------------- ##
-configure: WARNING:     ## Report this to https://github.com/tailix/libkernaux/issues ##
-configure: WARNING:     ## ---------------------------------------------------------- ##
-checking for stdarg.h... no
-checking stddef.h usability... no
-checking stddef.h presence... yes
-configure: WARNING: stddef.h: present but cannot be compiled
-configure: WARNING: stddef.h:     check for missing prerequisite headers?
-configure: WARNING: stddef.h: see the Autoconf documentation
-configure: WARNING: stddef.h:     section "Present But Cannot Be Compiled"
-configure: WARNING: stddef.h: proceeding with the compiler's result
-configure: WARNING:     ## ---------------------------------------------------------- ##
-configure: WARNING:     ## Report this to https://github.com/tailix/libkernaux/issues ##
-configure: WARNING:     ## ---------------------------------------------------------- ##
-checking for stddef.h... no
-```
-
 To install into specific directory use full path: `DESTDIR="$(pwd)/dest" make
 install` instead of `DESTDIR=dest make install`.
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Specify program versions #
 ############################
 
-AC_PREREQ([2.68])
+AC_PREREQ([2.70])
 LT_PREREQ([2.4.6])
 
 
@@ -325,7 +325,6 @@ AC_LANG([C])
 AM_PROG_AR
 AM_PROG_AS
 AC_PROG_CC
-AC_PROG_CC_C99
 AC_C_INLINE
 
 AC_HEADER_STDBOOL


### PR DESCRIPTION
To get rid of [a bug](https://savannah.gnu.org/support/index.php?110393) when configuring for a freestanding environment.